### PR TITLE
feat: make bot read token from a configuration file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .env
+config.ini

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+Create a `config.ini` in the same folder as the bot, with the following contents:
+
+```text
+[BOT]
+token = YOUR_DISCORD_TOKEN_HERE
+```
+
+From a command prompt, create a virtual environment for Python, install the requirements, then run `bot.py`, e.g.
+
+```
+python -m venv .env
+.env\Scripts\activate.bat
+pip install -r requirements.txt
+python bot.py
+```

--- a/bot.py
+++ b/bot.py
@@ -1,9 +1,9 @@
+import configparser
 import discord
 import os
 import random
 
 
-discord_token = 'TOKEN'
 intents = discord.Intents.default()
 intents.message_content = True
 client = discord.Client(intents=intents)
@@ -57,4 +57,14 @@ async def handle_phasmophobia(message):
     await send(message.channel, lines, percentage)
 
 
-client.run(discord_token)
+def start_client():
+    if not os.path.isfile('config.ini'):
+        raise Exception('Could not find configuration file')
+    config = configparser.ConfigParser()
+    config.read('config.ini')
+    token = config['BOT']['token']
+    client.run(token)
+
+
+if __name__ == '__main__':
+    start_client()


### PR DESCRIPTION
Modified the bot to read the Discord token from a configuration file, rather than forcing users to modify the Python itself. Also added a simple `README` explaining how to run the bot.