### PR TITLE
feat: changed bot to read token from a simple text file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 *.pyc
 .env
-config.ini
+.token

--- a/README.md
+++ b/README.md
@@ -1,9 +1,4 @@
-Create a `config.ini` in the same folder as the bot, with the following contents:
-
-```text
-[BOT]
-token = YOUR_DISCORD_TOKEN_HERE
-```
+Create a `.token` in the same folder as the bot, and set its contents to your Discord bot token (with no new line at the end of the file).
 
 From a command prompt, create a virtual environment for Python, install the requirements, then run `bot.py`, e.g.
 

--- a/bot.py
+++ b/bot.py
@@ -1,4 +1,3 @@
-import configparser
 import discord
 import os
 import rule
@@ -24,13 +23,16 @@ async def on_message(message):
 
 def start_client():
     global rules
-    if not os.path.isfile('config.ini'):
-        raise Exception('Could not find configuration file')
-    config = configparser.ConfigParser()
-    config.read('config.ini')
-    token = config['BOT']['token']
+    token = read_token('.token')
     rules = read_rules()
     client.run(token)
+
+
+def read_token(path):
+    if not os.path.isfile(path):
+        raise ValueError(f'No such file: {path}')
+    with open(path, 'r') as f:
+        return f.read()
 
 
 def read_rules():


### PR DESCRIPTION
Removed the use of the `configparser` package for reading the Discord bot token, instead relying on a simple text file. Simply put the token into a text file named `.token` and run the bot.