### PR TITLE
feat: moved token parsing out of the client

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -1,10 +1,18 @@
 import client
+import os
+
+
+def read_token(token_path):
+    if not os.path.isfile(token_path):
+        raise ValueError(f'No such file: {token_path}')
+    with open(token_path, 'r') as f:
+        return f.read()
 
 
 def main():
-    bot_client = client.RedmacBotClient('.token', 'rules.json')
-    bot_token = bot_client.token
-    bot_client.run(bot_token)
+    token = read_token('.token')
+    bot_client = client.RedmacBotClient('rules.json')
+    bot_client.run(token)
 
 
 if __name__ == '__main__':

--- a/src/client.py
+++ b/src/client.py
@@ -1,5 +1,4 @@
 import discord
-import os
 import rule
 
 
@@ -7,11 +6,10 @@ class RedmacBotClient(discord.Client):
     '''The main client for running the bot. Reads the token and parses the rules, the latter of which is used to
     determine how to respond to users.'''
 
-    def __init__(self, token_path, rules_path):
+    def __init__(self, rules_path):
         intents = discord.Intents.default()
         intents.message_content = True
         super().__init__(intents=intents)
-        self.token = self._read_token(token_path)
         self._rules = rule.Rules(rules_path)
     
     async def on_ready(self):
@@ -21,9 +19,3 @@ class RedmacBotClient(discord.Client):
         if message.author == self.user:
             return
         await self._rules.handle(message)
-
-    def _read_token(self, path):
-        if not os.path.isfile(path):
-            raise ValueError(f'No such file: {path}')
-        with open(path, 'r') as f:
-            return f.read()


### PR DESCRIPTION
Parsing of the Discord bot token was being done directly by the client, which needs the token to start. This led to weird behavior where the client would read the token, the application would then retrieve it from the client to then pass back into the client's `run` method. Rather than doing that, we put the onus of reading the token on the application instead.