### PR TITLE
feat: added idiom for logging messages

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -1,10 +1,13 @@
 import discord
+import logging
 import os
 import rule
 import time
 from discord.ext import commands
 
 
+LOGGER = logging.getLogger('discord.redmac.bot')
+LOGGER.setLevel(logging.DEBUG)
 INTENTS = discord.Intents.default()
 INTENTS.message_content = True
 
@@ -20,7 +23,7 @@ class RedmacBot(commands.Bot):
         self._last_read_time = time.time()
     
     async def on_ready(self):
-        print(f'{self.user} has connected to Discord!')
+        LOGGER.info(f'{self.user} has connected to Discord!')
 
     async def on_message(self, message):
         self._refresh_rules()
@@ -35,15 +38,16 @@ class RedmacBot(commands.Bot):
             # only refresh the rules if the file has changed
             mod_time = os.path.getmtime(self._rules_path)
             if mod_time < self._last_read_time:
-                print('No updates to rules, skipping')
+                LOGGER.debug('No updates to rules file, nothing to refresh')
                 return
 
             # try refreshing the rules; if they cannot be parsed, then keep the old rules
-            print('Refreshing rules')
+            LOGGER.debug('Refreshing posting rules')
             try:
                 new_rules = rule.Rules(self._rules_path)
-            except:
-                print('Failed to read rules')
+            except Exception as e:
+                LOGGER.warning(f'Failed to update rules, error: {e.message}')
                 return
             self._rules = new_rules
             self._last_read_time = time.time()
+            LOGGER.debug('Rules successfully refreshed')

--- a/src/rule.py
+++ b/src/rule.py
@@ -1,6 +1,11 @@
 import json
+import logging
 import os
 import random
+
+
+LOGGER = logging.getLogger('discord.redmac.rule')
+LOGGER.setLevel(logging.DEBUG)
 
 
 class Rules:
@@ -32,9 +37,17 @@ class Rules:
         for rule in self._rules:
             if rule.should_apply(message):
                 response = rule.get_response()
+                self._log_match(message, rule, response)
                 if response:
                     await message.channel.send(response)
                 break
+
+    def _log_match(self, message, rule, response):
+        LOGGER.debug('Found match for message:')
+        LOGGER.debug(f'   Message:  {message.content}')
+        LOGGER.debug(f'   Channel:  {message.channel.name}')
+        LOGGER.debug(f'   Author:   {message.author.name}')
+        LOGGER.debug(f"   Response: {response if response else '<empty>'}")
 
 
 class Rule:

--- a/src/rule.py
+++ b/src/rule.py
@@ -44,9 +44,10 @@ class Rules:
 
     def _log_match(self, message, rule, response):
         LOGGER.debug('Found match for message:')
-        LOGGER.debug(f'   Message:  {message.content}')
+        LOGGER.debug(f'   Category: {message.channel.category}')
         LOGGER.debug(f'   Channel:  {message.channel.name}')
         LOGGER.debug(f'   Author:   {message.author.name}')
+        LOGGER.debug(f'   Message:  {message.content}')
         LOGGER.debug(f"   Response: {response if response else '<empty>'}")
 
 


### PR DESCRIPTION
Added an idiom to the Python scripts for logging messages. The loggers follow the same pattern as the Discord API itself, using the `logging` module. For now the logs are verbose; this will be revisited as the bot gets more use.