### PR TITLE
feat: migrated from "discord.py" to "disnake" for Discord integration

### DIFF
--- a/etc/requirements.txt
+++ b/etc/requirements.txt
@@ -1,1 +1,1 @@
-discord.py==2.1.1
+disnake==2.8.0

--- a/src/bot.py
+++ b/src/bot.py
@@ -1,14 +1,14 @@
-import discord
+import disnake
 import logging
 import os
 import rule
 import time
-from discord.ext import commands
+from disnake.ext import commands
 
 
-LOGGER = logging.getLogger('discord.redmac.bot')
+LOGGER = logging.getLogger('redmac.bot')
 LOGGER.setLevel(logging.DEBUG)
-INTENTS = discord.Intents.default()
+INTENTS = disnake.Intents.default()
 INTENTS.message_content = True
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -4,7 +4,9 @@ import os
 
 
 def setup_logging():
-    logging.basicSetup(logging.INFO)
+    log_level = logging.INFO
+    log_format = '%(asctime)s | %(levelname)-7s | [%(name)s] %(message)s'
+    logging.basicConfig(level=log_level, format=log_format)
 
 
 def read_token(token_path):
@@ -15,6 +17,7 @@ def read_token(token_path):
 
 
 def main():
+    setup_logging()
     token = read_token('.token')
     redmac_bot = bot.RedmacBot('rules.json')
     redmac_bot.run(token)

--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,10 @@
 import bot
+import logging
 import os
+
+
+def setup_logging():
+    logging.basicSetup(logging.INFO)
 
 
 def read_token(token_path):

--- a/src/rule.py
+++ b/src/rule.py
@@ -4,7 +4,7 @@ import os
 import random
 
 
-LOGGER = logging.getLogger('discord.redmac.rule')
+LOGGER = logging.getLogger('redmac.rule')
 LOGGER.setLevel(logging.DEBUG)
 
 


### PR DESCRIPTION
Migrated to using the `disnake` API for communicating with Discord, as opposed to `discord.py`. This is due to better integration of slash commands, which I plan to implement in the future.