### PR TITLE
feat: added a slash command for providing details about Deep Rock Galactic stages

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1,3 +1,4 @@
+import cmd
 import logging
 import msg
 from disnake.ext import commands
@@ -13,12 +14,14 @@ class App:
 
     def __init__(self):
         self.bot: commands.Bot = None
+        self.command_handler: cmd.CommandHandler = None
         self.message_handler: msg.MessageHandler = None
 
     def initialize(self, bot: commands.Bot, rules_path: str):
         self.bot = bot
         self._setup_logging()
-        self.message_handler = msg.MessageHandler(bot, rules_path)
+        self.command_handler = cmd.CommandHandler()
+        self.message_handler = msg.MessageHandler(rules_path)
         LOGGER.info('Application successfully initialized')
 
     def _setup_logging(self):

--- a/src/cmd.py
+++ b/src/cmd.py
@@ -6,8 +6,11 @@ LOGGER = logging.getLogger('redmac.cmd')
 
 
 class CommandHandler:
+    '''Central class for handling slash commands.'''
 
     async def handle_drg(self, interaction: disnake.ApplicationCommandInteraction, length: int, complexity: int, location: str, mission_type: str, anomaly: str, mutator1: str, mutator2: str):
+        '''Given the parameters of a mission in Deep Rock Galactic (DRG), returns the computed hazard bonuses for the
+        different difficult levels as well as suggested perks to use on those missions.'''
 
         base_bonus = 0
         base_bonus += (length - 1) * 10

--- a/src/cmd.py
+++ b/src/cmd.py
@@ -1,0 +1,104 @@
+import disnake
+import logging
+
+
+LOGGER = logging.getLogger('redmac.cmd')
+
+
+class CommandHandler:
+
+    async def handle_drg(self, interaction: disnake.ApplicationCommandInteraction, length: int, complexity: int, location: str, mission_type: str, anomaly: str, mutator1: str, mutator2: str):
+
+        base_bonus = 0
+        base_bonus += (length - 1) * 10
+        base_bonus += (complexity - 1) * 10
+        base_bonus += self._get_hazard_bonus(mutator1)
+        base_bonus += self._get_hazard_bonus(mutator2)
+
+        passives = self._get_suggested_passive_perks(length, complexity, location, mission_type, anomaly, mutator1, mutator2)
+        actives = self._get_suggested_active_perks(length, complexity, location, mission_type, anomaly, mutator1, mutator2)
+
+        messages = [
+            '**__Mission Parameters__**',
+            f'**Mission Length**: {length}',
+            f'**Cave Complexity**: {complexity}',
+            f'**Biome**: {location}',
+            f'**Mission Type**: {mission_type}',
+            f'**Anomaly**: {anomaly}',
+            f'**Mutators**: {mutator1}/{mutator2}',
+            '',
+            '**__Hazard Bonuses__**',
+            f'**Hazard 1**: {base_bonus + 25}',
+            f'**Hazard 2**: {base_bonus + 50}',
+            f'**Hazard 3**: {base_bonus + 75}',
+            f'**Hazard 4**: {base_bonus + 100}',
+            f'**Hazard 5**: {base_bonus + 133}',
+            '',
+            '**__Suggested Perks__**',
+            f"**Passive**: {', '.join(passives) if len(passives) > 0 else '-'}",
+            f"**Active**: {', '.join(actives) if len(actives) > 0 else '-'}",
+        ]
+        await interaction.response.send_message('\n'.join(messages))
+
+    def _get_hazard_bonus(self, mutator):
+        bonuses = {
+            '-': 0,
+            'Cave Leech Cluster': 15,
+            'Elite Threat': 30,
+            'Exploder Infestation!': 20,
+            'Haunted Cave': 30,
+            'Lethal Enemies': 25,
+            'Lithophage Outbreak': 50,
+            'Low Oxygen': 20,
+            'Mactera Plague': 20,
+            'Parasites': 15,
+            'Regenerative Bugs': 15,
+            'Rival Presence': 30,
+            'Shield Disruption': 30,
+            'Swarmageddon': 20,
+        }
+        if mutator not in bonuses:
+            LOGGER.warning(f'Unknown mutator: {mutator}')
+            return 0
+        return bonuses[mutator]
+
+    def _get_suggested_passive_perks(self, length, complexity, location, mission_type, anomaly, mutator1, mutator2):
+
+        perks = set()
+
+        # location
+        if location in ('Fungus Bogs', 'Magma Core'):
+            perks.add('Unstoppable')
+        if location in ('Magma Core'):
+            perks.add('Elemental Insulation')
+
+        # mission types
+        if mission_type in ('Egg Hunt', 'Mining Expedition'):
+            perks.add('Deep Pockets')
+
+        # anomalies
+        if anomaly in ('Gold Rush', 'Golden Bugs', 'Mineral Mania'):
+            perks.add('Deep Pockets')
+        
+        # mutators
+        if 'Lethal Enemies' in (mutator1, mutator2):
+            perks.add('Thorns')
+        if 'Low Oxygen' in (mutator1, mutator2):
+            perks.add('Veteran Depositor')
+        if 'Shield Disruption' in (mutator1, mutator2):
+            perks.add('Sweet Tooth')
+            perks.add('Vampire')
+        if 'Swarmageddon' in (mutator1, mutator2):
+            perks.add('Thorns')
+        
+        return list(sorted(perks))
+    
+    def _get_suggested_active_perks(self, length, complexity, location, mission_type, anomaly, mutator1, mutator2):
+        perks = set()
+        if 'Cave Leech Cluster' in (mutator1, mutator2):
+            perks.add('Heightened Senses')
+        if 'Regenerative Bugs' in (mutator1, mutator2):
+            perks.add('Beast Master')
+        if 'Rival Presence' in (mutator1, mutator2):
+            perks.add('Heightened Senses')
+        return list(sorted(perks))

--- a/src/main.py
+++ b/src/main.py
@@ -18,7 +18,22 @@ async def on_ready():
 
 @bot.event
 async def on_message(message):
-    await app.message_handler.handle(message)
+    await app.message_handler.handle(bot, message)
+
+
+@bot.slash_command()
+async def drg(
+    self,
+    interaction: disnake.ApplicationCommandInteraction, 
+    length: int = commands.Param(choices=[1, 2, 3]),
+    complexity: int = commands.Param(choices=[1, 2, 3]),
+    location: str = commands.Param(choices=['Azure Weald', 'Crystalline Caverns', 'Dense Biozone', 'Fungus Bogs', 'Glacial Strata', 'Hollow Bough', 'Magma Core', 'Radioactive Exclusion Zone', 'Salt Pits', 'Sandblasted Corridors']),
+    mission_type: str = commands.Param(choices=['Deep Dive', 'Egg Hunt', 'Elimination', 'Escort Duty', 'Industrial Sabotage', 'Mining Expedition', 'On-site Refining', 'Point Extraction', 'Salvage Operation']),
+    anomaly: str = commands.Param(choices=['-', 'Critical Weakness', 'Double XP', 'Gold Rush', 'Golden Bugs', 'Low Gravity', 'Mineral Mania', 'Rich Atmosphere', 'Volatile Guts']),
+    mutator1: str = commands.Param(choices=['-', 'Cave Leech Cluster', 'Elite Threat', 'Exploder Infestation!', 'Haunted Cave', 'Lethal Enemies', 'Lithophage Outbreak', 'Low Oxygen', 'Mactera Plague', 'Parasites', 'Regenerative Bugs', 'Rival Presence', 'Shield Disruption', 'Swarmageddon']),
+    mutator2: str = commands.Param(choices=['-', 'Cave Leech Cluster', 'Elite Threat', 'Exploder Infestation!', 'Haunted Cave', 'Lethal Enemies', 'Lithophage Outbreak', 'Low Oxygen', 'Mactera Plague', 'Parasites', 'Regenerative Bugs', 'Rival Presence', 'Shield Disruption', 'Swarmageddon']),
+):
+    await app.command_handler.handle_drg(interaction, length, complexity, location, mission_type, anomaly, mutator1, mutator2)
 
 
 def read_token(token_path):

--- a/src/msg.py
+++ b/src/msg.py
@@ -1,3 +1,4 @@
+import disnake
 import logging
 import os
 import rule
@@ -13,16 +14,15 @@ class MessageHandler:
     file, and respond to the message accordingly. Automatically refreshes its rules every so often to prevent the need
     for restarting the bot on rule changes.'''
 
-    def __init__(self, bot: commands.Bot, rules_path: str):
-        self._bot = bot
+    def __init__(self, rules_path: str):
         self._rules_path = rules_path
         self._rules = rule.Rules(rules_path)
         self._last_read_time = time.time()
     
-    async def handle(self, message):
+    async def handle(self, bot: commands.Bot, message: disnake.Message):
         '''Handles the message, responding to it if necessary.'''
         self._refresh_rules()
-        if message.author == self._bot.user:
+        if message.author == bot.user:
             return
         await self._rules.handle(message)
 


### PR DESCRIPTION
Defines a new slash command, `/drg`, which can be used. The command receives a list of the mission parameters, and will emit details on the hazard bonuses for every difficulty, as well as some suggestions on what types of passive or active perks should be used on those missions.