### PR TITLE
chore: remove `.bot` from the `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 *.pyc
-.bot
 .token*


### PR DESCRIPTION
There is no longer a `.bot` directory created as part of this repository; hence, it was removed from the `.gitignore`.