### PR TITLE
feat: refactored `drg-quote` to load data from a JSON file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.12.1
 WORKDIR /bot
 COPY .token .
 COPY src .
-copy data data
+COPY data data
 COPY etc .
 RUN pip install -r requirements.txt
 CMD python main.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM python:3.12.1
 WORKDIR /bot
 COPY .token .
 COPY src .
+copy data data
 COPY etc .
 RUN pip install -r requirements.txt
 CMD python main.py

--- a/data/drg-quotes.json
+++ b/data/drg-quotes.json
@@ -1,0 +1,59 @@
+{
+    "quotes": [
+        {
+            "quote": "Where is that damn tin can?!",
+            "source": "Dwarf",
+            "scenario": "when calling for the MULE"
+        },
+        {
+            "quote": "I need the damn minecart on legs! Where is it?!",
+            "source": "Dwarf",
+            "scenario": "when calling for the MULE"
+        },
+        {
+            "quote": "Help! I'm stuck in the ceiling!",
+            "source": "Dwarf",
+            "scenario": "when grabbed by a cave leech"
+        },
+        {
+            "quote": "From A to D, skipping B and C!",
+            "source": "Scout",
+            "scenario": "when using the grappling hook"
+        },
+        {
+            "quote": "Ready to blow!",
+            "source": "Driller",
+            "scenario": "when placing a satchel charge"
+        },
+        {
+            "quote": "I call it my \"grenade-grenade\"!",
+            "source": "Gunner",
+            "scenario": "when throwing a cluster grenade"
+        },
+        {
+            "quote": "Multi-boom!",
+            "source": "Gunner",
+            "scenario": "when throwing a cluster grenade"
+        },
+        {
+            "quote": "Turrets and explosions! You've come to the right place, mate.",
+            "source": "Engineer",
+            "scenario": "when selected"
+        },
+        {
+            "quote": "Two-thousand rounds of depleted uranium, aw yeah!",
+            "source": "Gunner",
+            "scenario": "when selected"
+        },
+        {
+            "quote": "Allow me to \"illuminate\" the situation! Hahahaha!",
+            "source": "Scout",
+            "scenario": "when selected"
+        },
+        {
+            "quote": "If it ain't drillable, it's probably flammable.",
+            "source": "Driller",
+            "scenario": "when selected"
+        }
+    ]
+}

--- a/src/bot/drg/drg_quote.py
+++ b/src/bot/drg/drg_quote.py
@@ -1,21 +1,10 @@
+import json
 import random
 from disnake import ApplicationCommandInteraction
 from bot import bot
 
 
-quotes = [
-    ('Where is that damn tin can?!', 'Dwarf', 'when calling for the MULE'),
-    ('I need the damn minecart on legs! Where is it?!', 'Dwarf', 'when calling for the MULE'),
-    ("Help! I'm stuck in the ceiling!", 'Dwarf', 'when grabbed by a cave leech'),
-    ('From A to D, skipping B and C!', 'Scout', 'when using the grappling hook'),
-    ('Ready to blow!', 'Driller', 'when placing a satchel charge'),
-    ('I call it my "grenade-grenade"!', 'Gunner', 'when throwing a cluster grenade'),
-    ('Multi-boom!', 'Gunner', 'when throwing a cluster grenade'),
-    ("Turrets and explosions! You've come to the right place, mate.", 'Engineer', 'when selected'),
-    ('Two-thousand rounds of depleted uranium, aw yeah!', 'Gunner', 'when selected'),
-    ('Allow me to "illuminate" the situation! Hahahaha!', 'Scout', 'when selected'),
-    ("If it ain't drillable, it's probably flammable.", 'Driller', 'when selected'),
-]
+DATA_JSON = 'data/drg-quotes.json'
 
 
 @bot.slash_command(name='drg-quote', description='Returns a random quote from Deep Rock Galactic.')
@@ -24,7 +13,17 @@ async def drg_quote(self, interaction: ApplicationCommandInteraction):
 
 
 class DrgQuoteCommand:
+    '''Command for returning a random quote from Deep Rock Galactic.'''
+
     async def handle(self, interaction):
-        quote, speaker, situation = random.choice(quotes)
-        message = f'"{quote}" - {speaker}, {situation}'
+        with open(DATA_JSON, mode='r', encoding='utf-8') as f:
+            data = json.loads(f.read())
+        quotes = data['quotes']
+
+        selected = random.choice(quotes)
+        quote = selected['quote']
+        source = selected['source']
+        scenario = selected['scenario']
+
+        message = f'"{quote}" - {source}, {scenario}'
         await interaction.response.send_message(message)

--- a/src/bot/drg/drg_quote.py
+++ b/src/bot/drg/drg_quote.py
@@ -1,5 +1,5 @@
-import json
 import random
+import util.jsoncacher as jsoncacher
 from disnake import ApplicationCommandInteraction
 from bot import bot
 
@@ -7,8 +7,11 @@ from bot import bot
 DATA_JSON = 'data/drg-quotes.json'
 
 
-@bot.slash_command(name='drg-quote', description='Returns a random quote from Deep Rock Galactic.')
-async def drg_quote(self, interaction: ApplicationCommandInteraction):
+@bot.slash_command(
+    name='drg-quote',
+    description='Returns a random quote from Deep Rock Galactic.'
+)
+async def drg_quote(interaction: ApplicationCommandInteraction):
     await DrgQuoteCommand().handle(interaction)
 
 
@@ -16,8 +19,7 @@ class DrgQuoteCommand:
     '''Command for returning a random quote from Deep Rock Galactic.'''
 
     async def handle(self, interaction):
-        with open(DATA_JSON, mode='r', encoding='utf-8') as f:
-            data = json.loads(f.read())
+        data = jsoncacher.get(DATA_JSON)
         quotes = data['quotes']
 
         selected = random.choice(quotes)


### PR DESCRIPTION
Refactors the `drg-quote` command to load data from a JSON file rather than directly from Python code. Uses the new `jsoncacher` module to do so.